### PR TITLE
4. Desactivar el manejador de promesas y Selenium server

### DIFF
--- a/protractor/local.config.ts
+++ b/protractor/local.config.ts
@@ -4,7 +4,7 @@ import { reporter } from './helpers/reporter';
 export const config: Config = {
   framework: 'jasmine',
   specs: [ '../test/google.spec.js' ],
-  seleniumAddress: 'http://localhost:4444/wd/hub',
+  SELENIUM_PROMISE_MANAGER : false,
   onPrepare: () => {
     browser.ignoreSynchronization = true;
     reporter();

--- a/test/google.spec.ts
+++ b/test/google.spec.ts
@@ -1,9 +1,13 @@
 import { browser } from 'protractor';
 
-describe('This is the first example of protractor', () => {
-  it('should have a title', () => {
-    browser.ignoreSynchronization = true;
-    browser.get('http://www.google.com');
-    expect(browser.getTitle()).toEqual('Google');
+describe('Given a SDET learning protractor', () => {
+  describe('when open Google Page', () => {
+    beforeEach(async () => {
+      await browser.get('http://www.google.com');
+    });
+
+    it('then should have a title', async () => {
+      await expect(browser.getTitle()).toEqual('Google');
+    });
   });
 });


### PR DESCRIPTION
Descripción: Para Octubre del 2018 WebDriverJS dejará de dar soporte a un tipo de promesas personalizadas que ha trabajado desde sus inicios, aunque hoy en día aún hay soporte es necesario empezar a trabajar de la forma que recomienda Protractor

1. Eliminar la propiedad seleniumAddress del local.config.ts
2. Termine el proceso del webdriver start (ya no es necesario)
3. Agregar la propiedad SELENIUM_PROMISE_MANAGER con el valor false en el local.config.ts
4. Modificar el archivo de google.spec.ts para que trabaje con async/await