### PR TITLE
5. Chrome Headless

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "npm run clean && tsc",
-    "test": "npm run build && protractor dist/protractor/local.config.js"
+    "test:local": "npm run build && protractor dist/protractor/local.config.js",
+    "test:headless": "npm run build && protractor dist/protractor/headless.config.js"
   },
   "repository": {
     "type": "git",

--- a/protractor/headless.config.ts
+++ b/protractor/headless.config.ts
@@ -1,0 +1,18 @@
+import { browser, Config } from 'protractor';
+import { reporter } from './helpers/reporter';
+
+export const config: Config = {
+  framework: 'jasmine',
+  specs: [ '../test/google.spec.js' ],
+  SELENIUM_PROMISE_MANAGER : false,
+  onPrepare: () => {
+    browser.ignoreSynchronization = true;
+    reporter();
+  },
+  capabilities: {
+    browserName: 'chrome',
+    chromeOptions: {
+      args: ['--headless', '--disable-gpu']
+    }
+  }
+};


### PR DESCRIPTION
Descripción: Muchas veces no contamos con servidores de integración continua que tengan acceso a máquinas con interfaz gráfica. Existen algunos navegadores que tienen versión headless que funcionan sin interfaz gráfica pero se comportan muy similar a los navegadores comunes. En esta sesión vamos a configurar la versión headless de chrome

1. Duplicar el archivo local.config.ts con el nombre de headless.config.ts
2. Agregar la propiedad de capabilities en el nuevo archivo con la siguiente información
3. Duplicar el script test del package.json con el nombre de test:headless y cambia la ruta de ejecución al archivo headless.conf.js
4. Cambia el nombre del script test por test:local
5. Ejecuta tanto el comando npm run test:local como el npm run test:headless para comprobar que ejecuta efectivamente