### PR TITLE
11. Esperas de Carga de Página y de Jasmine

### DIFF
--- a/protractor/headless.config.ts
+++ b/protractor/headless.config.ts
@@ -4,7 +4,10 @@ import { reporter } from './helpers/reporter';
 export const config: Config = {
   framework: 'jasmine',
   specs: ['../test/**/*.spec.js'],
-  getPageTimeout: 1000,
+  getPageTimeout: 3000,
+  jasmineNodeOpts: {
+    defaultTimeoutInterval: 120000
+  },
   SELENIUM_PROMISE_MANAGER : false,
   onPrepare: () => {
     browser.ignoreSynchronization = true;

--- a/protractor/local.config.ts
+++ b/protractor/local.config.ts
@@ -4,7 +4,10 @@ import { reporter } from './helpers/reporter';
 export const config: Config = {
   framework: 'jasmine',
   specs: ['../test/**/*.spec.js'],
-  getPageTimeout: 1000,
+  getPageTimeout: 3000,
+  jasmineNodeOpts: {
+    defaultTimeoutInterval: 120000
+  },
   SELENIUM_PROMISE_MANAGER : false,
   onPrepare: () => {
     browser.ignoreSynchronization = true;

--- a/test/buy-tshirt.spec.ts
+++ b/test/buy-tshirt.spec.ts
@@ -23,9 +23,6 @@ describe('Buy a t-shirt', () => {
   const paymentStepPage: PaymentStepPage = new PaymentStepPage();
   const bankPaymentPage: BankPaymentPage = new BankPaymentPage();
   const orderSummaryPage: OrderSummaryPage = new OrderSummaryPage();
-  beforeEach(() => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
-  });
 
   it('then should be bought a t-shirt', async () => {
     await browser.get('http://automationpractice.com/');


### PR DESCRIPTION
Descripción: Las esperas en selenium son los tiempos que se esperará para realizar algunas acciones, conocerlos y saber cómo utilizarlos nos disminuirá la fragilidad de las pruebas y adicionalmente nos ayudará a reducir los tiempos de ejecución.

1. Cambia el valor del getPageTimeout por 30000 en los archivos de configuración de protractor
2. Elimina el sleep de 10000
3. Ejecutar las pruebas y verifica que aun sigan funcionando
4. Agregar el tiempo de espera de Jasmine dentro de los archivos de configuración como muestra la siguiente imagen
jasmineNodeOpts: {
  defaultTimeoutInterval: 120000
}
5. Eliminar el beforeEach de la prueba
6. Ejecute las pruebas tanto con interfaz gráfica como en modo headless. Si alguna prueba falla modificarla utilizando css locators o los tiempos hasta que logre funcionar
7. Solicite la revisión de código tal como se hizo en el punto anterior