### PR TITLE
13. Esperas Explicitas

### DIFF
--- a/protractor/headless.config.ts
+++ b/protractor/headless.config.ts
@@ -4,14 +4,14 @@ import { reporter } from './helpers/reporter';
 export const config: Config = {
   framework: 'jasmine',
   specs: ['../test/**/*.spec.js'],
-  getPageTimeout: 3000,
+  getPageTimeout: 30000,
   jasmineNodeOpts: {
     defaultTimeoutInterval: 120000
   },
   SELENIUM_PROMISE_MANAGER : false,
   onPrepare: () => {
     browser.ignoreSynchronization = true;
-    browser.manage().timeouts().implicitlyWait(3000);
+    browser.manage().timeouts().implicitlyWait(0);
     reporter();
   },
   capabilities: {

--- a/protractor/local.config.ts
+++ b/protractor/local.config.ts
@@ -4,14 +4,14 @@ import { reporter } from './helpers/reporter';
 export const config: Config = {
   framework: 'jasmine',
   specs: ['../test/**/*.spec.js'],
-  getPageTimeout: 3000,
+  getPageTimeout: 30000,
   jasmineNodeOpts: {
     defaultTimeoutInterval: 120000
   },
   SELENIUM_PROMISE_MANAGER : false,
   onPrepare: () => {
     browser.ignoreSynchronization = true;
-    browser.manage().timeouts().implicitlyWait(3000);
+    browser.manage().timeouts().implicitlyWait(0);
     reporter();
   }
 };

--- a/src/page/product-added-modal.page.ts
+++ b/src/page/product-added-modal.page.ts
@@ -1,4 +1,4 @@
-import { $, ElementFinder } from 'protractor';
+import { $, ElementFinder, browser, ExpectedConditions } from 'protractor';
 
 export class ProductAddedModalPage {
   private checkoutButton: ElementFinder;
@@ -8,6 +8,7 @@ export class ProductAddedModalPage {
   }
 
   public async goToCheckoutButton(): Promise<void> {
+    await browser.wait(ExpectedConditions.elementToBeClickable(this.checkoutButton), 5000);
     await this.checkoutButton.click();
   }
 }


### PR DESCRIPTION
Descripción: Las esperas explícitas es la más recomendada, ya que nos permite hacer esperas puntuales sobre algunos elementos y no sobre todos. En esta sesión desactivaremos las esperas implícitas y activaremos las explícitas donde sea necesario

1. Modificar los archivos de configuración de tal forma que desactive las esperas implicitas
browser.manage().timeouts().implicitlyWait(0)
2. Ejecute la prueba e identifique en qué partes la prueba falla
3. Utiliza esperas explícitas para solucionar las fallas de la prueba. busque apoyo de browser y ExpectedConditions
4. Ejecute las pruebas tanto con interfaz gráfica como en modo headless. Si alguna prueba falla modificarla utilizando css locators o los tiempos hasta que logre funcionar
5. Solicite la revisión de código tal como se hizo en el punto anterio